### PR TITLE
Add iOS logout bridging method

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 #### Android
 
-1. Open up `android/app/src/main/java/[...]/MainActivity.java`
+1. Open up `android/app/src/main/java/[...]/MainApplication.java`
   - Add `import com.armandoassuncao.RNCaMasPackage;` to the imports at the top of the file
   - Add `new RNCaMasPackage()` to the list returned by the `getPackages()` method
 2. Append the following lines to `android/settings.gradle`:

--- a/ios/RNCaMasUser.m
+++ b/ios/RNCaMasUser.m
@@ -14,6 +14,7 @@
 RCT_EXPORT_MODULE(CaMASUser)
 
 NSString *E_LOGIN_ERROR = @"E_LOGIN_ERROR";
+NSString *E_LOGOUT_ERROR = @"E_LOGOUT_ERROR";
 
 RCT_EXPORT_METHOD(getAuthCredentialsType
     :(RCTPromiseResolveBlock)resolve
@@ -41,6 +42,19 @@ RCT_EXPORT_METHOD(login
             reject(E_LOGIN_ERROR, error.localizedDescription, error);
         }
         else {
+            resolve(@(completed));
+        }
+    }];
+}
+
+RCT_EXPORT_METHOD(logout
+      :(RCTPromiseResolveBlock)resolve
+      rejecter:(RCTPromiseRejectBlock)reject
+) {
+    [[MASUser currentUser] logoutWithCompletion:^(BOOL completed, NSError * _Nullable error) {
+        if (error) {
+            reject(E_LOGOUT_ERROR, error.localizedDescription, error);
+        } else {
             resolve(@(completed));
         }
     }];


### PR DESCRIPTION
# Summary

Adds the bridging method for `[[MASUser currentUser] logoutWithCompletion]` on iOS, also fixes a reference to an incorrect file in the docs.