### PR TITLE
add functionality to send MASUser across bridge in iOS

### DIFF
--- a/ios/Categories/NSObject+NSDictionary.h
+++ b/ios/Categories/NSObject+NSDictionary.h
@@ -1,0 +1,7 @@
+#import <Foundation/Foundation.h>
+
+@interface NSObject (NSDictionary)
+
+-(NSMutableDictionary *)getDictionary;
+
+@end

--- a/ios/Categories/NSObject+NSDictionary.m
+++ b/ios/Categories/NSObject+NSDictionary.m
@@ -1,0 +1,33 @@
+#import "NSObject+NSDictionary.h"
+#import "objc/runtime.h"
+
+@implementation NSObject (KJObjectSerializer)
+
+-(NSMutableDictionary *)getDictionary
+{
+    Class klass = self.class;
+    if (klass == NULL) {
+        return nil;
+    }
+    
+    unsigned int outCount, i;
+    objc_property_t *properties = class_copyPropertyList(klass, &outCount);
+    NSMutableDictionary * results = [NSMutableDictionary dictionaryWithCapacity:outCount];
+    for (i = 0; i < outCount; i++) {
+        objc_property_t property = properties[i];
+        const char *propName = property_getName(property);
+        if(propName) {
+            NSString *propertyName = [NSString stringWithUTF8String:propName];
+            
+            NSString * value = [self valueForKey:propertyName];
+            if (value) {
+                [results setObject:value forKey:propertyName];
+            }
+        }
+    }
+    free(properties);
+    
+    return results;
+}
+
+@end

--- a/ios/RNCaMas.xcodeproj/project.pbxproj
+++ b/ios/RNCaMas.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		340C622E1FB632F400C5318D /* RNCaMasUser.m in Sources */ = {isa = PBXBuildFile; fileRef = 340C622D1FB632F400C5318D /* RNCaMasUser.m */; };
 		B3E7B58A1CC2AC0600A0062D /* RNCaMas.m in Sources */ = {isa = PBXBuildFile; fileRef = B3E7B5891CC2AC0600A0062D /* RNCaMas.m */; };
+		BE8D32D22142951C006FFC8D /* NSObject+NSDictionary.m in Sources */ = {isa = PBXBuildFile; fileRef = BE8D32D12142951C006FFC8D /* NSObject+NSDictionary.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -30,6 +31,8 @@
 		340C62381FB631B600C5318D /* frameworks */ = {isa = PBXFileReference; lastKnownFileType = folder; path = frameworks; sourceTree = "<group>"; };
 		B3E7B5881CC2AC0600A0062D /* RNCaMas.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNCaMas.h; sourceTree = "<group>"; };
 		B3E7B5891CC2AC0600A0062D /* RNCaMas.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNCaMas.m; sourceTree = "<group>"; };
+		BE8D32D0214294FF006FFC8D /* NSObject+NSDictionary.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSObject+NSDictionary.h"; sourceTree = "<group>"; };
+		BE8D32D12142951C006FFC8D /* NSObject+NSDictionary.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSObject+NSDictionary.m"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -59,8 +62,18 @@
 				340C622D1FB632F400C5318D /* RNCaMasUser.m */,
 				B3E7B5881CC2AC0600A0062D /* RNCaMas.h */,
 				B3E7B5891CC2AC0600A0062D /* RNCaMas.m */,
+				BE8D32CF214294DE006FFC8D /* Categories */,
 				134814211AA4EA7D00B7C361 /* Products */,
 			);
+			sourceTree = "<group>";
+		};
+		BE8D32CF214294DE006FFC8D /* Categories */ = {
+			isa = PBXGroup;
+			children = (
+				BE8D32D0214294FF006FFC8D /* NSObject+NSDictionary.h */,
+				BE8D32D12142951C006FFC8D /* NSObject+NSDictionary.m */,
+			);
+			path = Categories;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -119,6 +132,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BE8D32D22142951C006FFC8D /* NSObject+NSDictionary.m in Sources */,
 				340C622E1FB632F400C5318D /* RNCaMasUser.m in Sources */,
 				B3E7B58A1CC2AC0600A0062D /* RNCaMas.m in Sources */,
 			);

--- a/ios/RNCaMasUser.m
+++ b/ios/RNCaMasUser.m
@@ -1,4 +1,5 @@
 #import "RNCaMasUser.h"
+#import "NSObject+NSDictionary.h"
 
 #import <MASFoundation/MASFoundation.h>
 #import <MASConnecta/MASConnecta.h>
@@ -27,7 +28,7 @@ RCT_EXPORT_METHOD(getCurrentUser
     :(RCTPromiseResolveBlock)resolve
     rejecter:(RCTPromiseRejectBlock)reject
 ) {
-    resolve([MASUser currentUser]);
+    resolve([[MASUser currentUser] getDictionary]);
 }
 
 RCT_EXPORT_METHOD(login


### PR DESCRIPTION
When calling getCurrentUser() through the bridge on iOS, it would send over a "null" as a string even when a valid MASUser was present.

This PR grabs adds a category to NSObject to convert the MASUser to an NSDictionary which is compatible serialisable type through the react-native bridge.