### PR TITLE
Update Min SDK version on 21

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -15,7 +15,7 @@ android {
     buildToolsVersion "26.0.2"
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 26
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
Updates the min required sdk version on Android to 21 to fix issues with multidex when building.